### PR TITLE
[Hotfix] Redefine the relationship between the class `Model` and `CanvasManager`.

### DIFF
--- a/DualViewsDrawingModel/Model.cs
+++ b/DualViewsDrawingModel/Model.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace DualViewsDrawingModel
+﻿namespace DualViewsDrawingModel
 {
     public class Model
     {
@@ -43,13 +41,9 @@ namespace DualViewsDrawingModel
         private const string ERROR_CANVAS_MANAGER_IS_NULL = "The given canvas manager is null.";
         private CanvasManager _canvasManager;
 
-        public Model(CanvasManager canvasManagerData)
+        public Model()
         {
-            if ( canvasManagerData == null )
-            {
-                throw new ArgumentNullException(ERROR_CANVAS_MANAGER_IS_NULL);
-            }
-            _canvasManager = canvasManagerData;
+            _canvasManager = new CanvasManager();
         }
 
         /// <summary>

--- a/DualViewsDrawingModelTest/ModelTest.cs
+++ b/DualViewsDrawingModelTest/ModelTest.cs
@@ -1,7 +1,6 @@
 ﻿using DualViewsDrawingModelTest;
 using DualViewsDrawingModelTest.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 
 namespace DualViewsDrawingModel.Test
 {
@@ -9,9 +8,9 @@ namespace DualViewsDrawingModel.Test
     public class ModelTest
     {
         private const string MEMBER_VARIABLE_NAME_CANVAS_MANAGER = "_canvasManager";
-        private CanvasManagerMock _canvasManager;
         private Model _model;
         private PrivateObject _target;
+        private CanvasManagerMock _canvasManager;
 
         /// <summary>
         /// Initializes this instance.
@@ -20,9 +19,10 @@ namespace DualViewsDrawingModel.Test
         [DeploymentItem(TestDefinitions.OUTPUT_ITEM_FILE_PATH)]
         public void Initialize()
         {
-            _canvasManager = new CanvasManagerMock();
-            _model = new Model(_canvasManager);
+            _model = new Model();
             _target = new PrivateObject(_model);
+            _canvasManager = new CanvasManagerMock();
+            _target.SetFieldOrProperty(MEMBER_VARIABLE_NAME_CANVAS_MANAGER, _canvasManager);
         }
 
         /// <summary>
@@ -69,11 +69,9 @@ namespace DualViewsDrawingModel.Test
         [TestMethod()]
         public void TestModel()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => new Model(null));
-            var canvasManager = new CanvasManagerMock();
-            var model = new Model(canvasManager);
+            var model = new Model();
             var target = new PrivateObject(model);
-            Assert.AreSame(target.GetFieldOrProperty(MEMBER_VARIABLE_NAME_CANVAS_MANAGER), canvasManager);
+            Assert.IsNotNull(target.GetFieldOrProperty(MEMBER_VARIABLE_NAME_CANVAS_MANAGER));
         }
 
         /// <summary>

--- a/DualViewsDrawingWindowsFormsApplication/Program.cs
+++ b/DualViewsDrawingWindowsFormsApplication/Program.cs
@@ -15,7 +15,7 @@ namespace DualViewsDrawingWindowsFormsApplication
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new DrawingForm(new DrawingPresentationModel(), new Model(new CanvasManager())));
+            Application.Run(new DrawingForm(new DrawingPresentationModel(), new Model()));
         }
     }
 }

--- a/DualViewsDrawingWindowsUniversalApplication/App.xaml.cs
+++ b/DualViewsDrawingWindowsUniversalApplication/App.xaml.cs
@@ -28,7 +28,7 @@ namespace DualViewsDrawingWindowsUniversalApplication
             this.InitializeComponent();
             this.Suspending += OnSuspending;
             _drawingPresentationModel = new DrawingPresentationModel();
-            _model = new Model(new CanvasManager());
+            _model = new Model();
             _drawingPageNavigationEventArgumentsParameter = new DrawingPageNavigationEventArgumentsParameter(_drawingPresentationModel, _model);
 
         }


### PR DESCRIPTION
Redefine the relationship between the class `Model` and `CanvasManager` from Association to Composition.